### PR TITLE
Initial MIPS64 support

### DIFF
--- a/il.cpp
+++ b/il.cpp
@@ -73,9 +73,13 @@ static size_t GetILOperandMemoryAddress(LowLevelILFunction& il, InstructionOpera
 static size_t ReadILOperand(LowLevelILFunction& il,
 	const Instruction& instr,
 	size_t i,
-	size_t addrSize = 4,
+	size_t registerSize,
+	size_t addrSize = SIZE_MAX,
 	bool isAddress = false)
 {
+	if (addrSize == SIZE_MAX) {
+		addrSize = registerSize;
+	}
 	InstructionOperand operand = instr.operands[i - 1];
 	switch (operand.operandClass)
 	{
@@ -83,15 +87,15 @@ static size_t ReadILOperand(LowLevelILFunction& il,
 		return il.Undefined();
 	case IMM:
 		if (isAddress)
-			return il.Operand(i - 1, il.ConstPointer(4, operand.immediate));
-		return il.Operand(i - 1, il.Const(4, operand.immediate));
+			return il.Operand(i - 1, il.ConstPointer(registerSize, operand.immediate));
+		return il.Operand(i - 1, il.Const(registerSize, operand.immediate));
 	case MEM_REG:
 	case MEM_IMM:
-		return il.Operand(i - 1, il.Load(addrSize, GetILOperandMemoryAddress(il, operand, 4)));
+		return il.Operand(i - 1, il.Load(addrSize, GetILOperandMemoryAddress(il, operand, registerSize)));
 	default:
 		if (operand.reg == REG_ZERO)
-			return il.Operand(i - 1, il.Const(4, 0));
-		return il.Operand(i - 1, il.Register(4, operand.reg));
+			return il.Operand(i - 1, il.Const(registerSize, 0));
+		return il.Operand(i - 1, il.Register(registerSize, operand.reg));
 	}
 }
 
@@ -106,9 +110,9 @@ static size_t WriteILOperand(LowLevelILFunction& il, Instruction& instr, size_t 
 		return il.Undefined();
 	case MEM_IMM:
 	case MEM_REG:
-		return il.Operand(i - 1, il.Store(4, GetILOperandMemoryAddress(il, operand, addrSize), value));
+		return il.Operand(i - 1, il.Store(addrSize, GetILOperandMemoryAddress(il, operand, addrSize), value));
 	default:
-		return il.Operand(i - 1, SetRegisterOrNop(il, 4, operand.reg, value));
+		return il.Operand(i - 1, SetRegisterOrNop(il, addrSize, operand.reg, value));
 	}
 }
 
@@ -159,32 +163,32 @@ static void ConditionalJump(Architecture* arch, LowLevelILFunction& il, size_t c
 	il.AddInstruction(il.Jump(il.ConstPointer(addrSize, f)));
 }
 
-ExprId GetConditionForInstruction(LowLevelILFunction& il, Instruction& instr)
+ExprId GetConditionForInstruction(LowLevelILFunction& il, Instruction& instr, size_t registerSize)
 {
 	switch (instr.operation)
 	{
 	case MIPS_BEQ:
 	case MIPS_BEQL:
-		return il.CompareEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2));
+		return il.CompareEqual(registerSize, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize));
 	case MIPS_BNE:
 	case MIPS_BNEL:
-		return il.CompareNotEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2));
+		return il.CompareNotEqual(registerSize, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize));
 	case MIPS_BEQZ:
-		return il.CompareEqual(4, ReadILOperand(il, instr, 1), il.Const(4, 0));
+		return il.CompareEqual(registerSize, ReadILOperand(il, instr, 1, registerSize), il.Const(registerSize, 0));
 	case MIPS_BGEZ:
 	case MIPS_BGEZL:
 	case MIPS_BGEZAL:
-		return il.CompareSignedGreaterEqual(4, ReadILOperand(il, instr, 1), il.Const(4, 0));
+		return il.CompareSignedGreaterEqual(registerSize, ReadILOperand(il, instr, 1, registerSize), il.Const(registerSize, 0));
 	case MIPS_BGTZ:
 	case MIPS_BGTZL:
-		return il.CompareSignedGreaterThan(4, ReadILOperand(il, instr, 1), il.Const(4, 0));
+		return il.CompareSignedGreaterThan(registerSize, ReadILOperand(il, instr, 1, registerSize), il.Const(registerSize, 0));
 	case MIPS_BLEZ:
 	case MIPS_BLEZL:
-		return il.CompareSignedLessEqual(4, ReadILOperand(il, instr, 1), il.Const(4, 0));
+		return il.CompareSignedLessEqual(registerSize, ReadILOperand(il, instr, 1, registerSize), il.Const(registerSize, 0));
 	case MIPS_BLTZ:
 	case MIPS_BLTZL:
 	case MIPS_BLTZAL:
-		return il.CompareSignedLessThan(4, ReadILOperand(il, instr, 1), il.Const(4, 0));
+		return il.CompareSignedLessThan(registerSize, ReadILOperand(il, instr, 1, registerSize), il.Const(registerSize, 0));
 	case MIPS_BC1F:
 	case MIPS_BC1FL:
 		if (instr.operands[0].operandClass == FLAG)
@@ -209,6 +213,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 	InstructionOperand& op3 = instr.operands[2];
 	InstructionOperand& op4 = instr.operands[3];
 	LowLevelILLabel trueCode, falseCode, again;
+	size_t registerSize = addrSize;
 	switch (instr.operation)
 	{
 		case MIPS_ADD:
@@ -216,69 +221,82 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_ADDI:
 		case MIPS_ADDIU:
 			if (op2.reg == REG_ZERO)
-				il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 3)));
+				il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 3, registerSize)));
 			else
 				il.AddInstruction(
 					SetRegisterOrNop(il, 4, op1.reg,
 						il.Add(4,
-							ReadILOperand(il, instr, 2),
-							ReadILOperand(il, instr, 3))));
+							ReadILOperand(il, instr, 2, registerSize),
+							ReadILOperand(il, instr, 3, registerSize))));
+			break;
+		case MIPS_DADD:
+		case MIPS_DADDU:
+		case MIPS_DADDI:
+		case MIPS_DADDIU:
+			if (op2.reg == REG_ZERO)
+				il.AddInstruction(SetRegisterOrNop(il, 8, op1.reg, ReadILOperand(il, instr, 3, registerSize)));
+			else
+				il.AddInstruction(
+					SetRegisterOrNop(il, 8, op1.reg,
+						il.Add(8,
+							ReadILOperand(il, instr, 2, registerSize),
+							ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_SUB:
 		case MIPS_SUBU:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.Sub(4,
-									ReadILOperand(il, instr, 2),
-									ReadILOperand(il, instr, 3))));
+									ReadILOperand(il, instr, 2, registerSize),
+									ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_AND:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.And(4,
-									ReadILOperand(il, instr, 2),
-									ReadILOperand(il, instr, 3))));
+									ReadILOperand(il, instr, 2, registerSize),
+									ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_ANDI:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.And(4,
-									ReadILOperand(il, instr, 2),
+									ReadILOperand(il, instr, 2, registerSize),
 									il.Operand(1, il.Const(4, 0x0000ffff & op3.immediate)))));
 			break;
 		case MIPS_DIV:
 			il.AddInstruction(il.SetRegister(4, REG_LO,
 								il.DivSigned(4,
-									ReadILOperand(il, instr, 1),
-									ReadILOperand(il, instr, 2))));
+									ReadILOperand(il, instr, 1, registerSize),
+									ReadILOperand(il, instr, 2, registerSize))));
 			il.AddInstruction(il.SetRegister(4, REG_HI,
 									il.ModSigned(4,
-										ReadILOperand(il, instr, 1),
-										ReadILOperand(il, instr, 2))));
+										ReadILOperand(il, instr, 1, registerSize),
+										ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_DIVU:
 			il.AddInstruction(il.SetRegister(4, REG_LO,
 									il.DivUnsigned(4,
-										ReadILOperand(il, instr, 1),
-										ReadILOperand(il, instr, 2))));
+										ReadILOperand(il, instr, 1, registerSize),
+										ReadILOperand(il, instr, 2, registerSize))));
 			il.AddInstruction(il.SetRegister(4, REG_HI,
 									il.ModUnsigned(4,
-										ReadILOperand(il, instr, 1),
-										ReadILOperand(il, instr, 2))));
+										ReadILOperand(il, instr, 1, registerSize),
+										ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_MUL:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.Mult(4,
-									ReadILOperand(il, instr, 2),
-									ReadILOperand(il, instr, 3))));
+									ReadILOperand(il, instr, 2, registerSize),
+									ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_XOR:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.Xor(4,
-									ReadILOperand(il, instr, 2),
-									ReadILOperand(il, instr, 3))));
+									ReadILOperand(il, instr, 2, registerSize),
+									ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_XORI:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 									il.Xor(4,
-										ReadILOperand(il, instr, 2),
+										ReadILOperand(il, instr, 2, registerSize),
 										il.Operand(1,il.Const(4, 0x0000ffff & op3.immediate)))));
 			break;
 		case MIPS_B:
@@ -297,7 +315,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_BNE:
 		case MIPS_BEQL: //Branch likely
 		case MIPS_BNEL:
-			ConditionalJump(arch, il, GetConditionForInstruction(il, instr), addrSize, op3.immediate, addr + 8);
+			ConditionalJump(arch, il, GetConditionForInstruction(il, instr, registerSize), addrSize, op3.immediate, addr + 8);
 			return false;
 
 		case MIPS_BEQZ:
@@ -309,7 +327,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_BGTZL:
 		case MIPS_BLEZL:
 		case MIPS_BLTZL:
-			ConditionalJump(arch, il, GetConditionForInstruction(il, instr), addrSize, op2.immediate, addr + 8);
+			ConditionalJump(arch, il, GetConditionForInstruction(il, instr, registerSize), addrSize, op2.immediate, addr + 8);
 			return false;
 
 		case MIPS_BC1F:
@@ -330,9 +348,9 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 
 		case MIPS_BGEZAL:
 		case MIPS_BLTZAL:
-			il.AddInstruction(il.If(GetConditionForInstruction(il, instr), trueCode, falseCode));
+			il.AddInstruction(il.If(GetConditionForInstruction(il, instr, registerSize), trueCode, falseCode));
 			il.MarkLabel(trueCode);
-			il.AddInstruction(il.Call(ReadILOperand(il, instr, 2)));
+			il.AddInstruction(il.Call(ReadILOperand(il, instr, 2, registerSize)));
 			il.MarkLabel(falseCode);
 			break;
 
@@ -354,7 +372,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(il.SetRegister(1, LLIL_TEMP(0), il.Const(4,0)));
 			il.MarkLabel(again);
 			il.AddInstruction(il.If(il.CompareNotEqual(4,
-					il.And(4, il.ShiftLeft(4, ReadILOperand(il, instr, 2), il.Register(1, LLIL_TEMP(0))), il.Const(4, 0x80000000)),
+					il.And(4, il.ShiftLeft(4, ReadILOperand(il, instr, 2, registerSize), il.Register(1, LLIL_TEMP(0))), il.Const(4, 0x80000000)),
 					il.Const(4,0)), trueCode, falseCode));
 			il.MarkLabel(trueCode);
 			il.AddInstruction(il.SetRegister(1, LLIL_TEMP(0), il.Add(1, il.Const(1,1), il.Register(1, LLIL_TEMP(0)))));
@@ -376,7 +394,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(il.SetRegister(1, LLIL_TEMP(0), il.Const(4,0)));
 			il.MarkLabel(again);
 			il.AddInstruction(il.If(il.CompareEqual(4,
-					il.And(4, il.ShiftLeft(4, ReadILOperand(il, instr, 2), il.Register(1, LLIL_TEMP(0))), il.Const(4, 0x80000000)),
+					il.And(4, il.ShiftLeft(4, ReadILOperand(il, instr, 2, registerSize), il.Register(1, LLIL_TEMP(0))), il.Const(4, 0x80000000)),
 					il.Const(4,0)), trueCode, falseCode));
 			il.MarkLabel(trueCode);
 			il.AddInstruction(il.SetRegister(1, LLIL_TEMP(0), il.Add(1, il.Const(1,1), il.Register(1, LLIL_TEMP(0)))));
@@ -397,16 +415,16 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_JR:
 		case MIPS_JR_HB:
 			if (op1.reg == REG_RA)
-				il.AddInstruction(il.Return(ReadILOperand(il, instr, 1)));
+				il.AddInstruction(il.Return(ReadILOperand(il, instr, 1, registerSize)));
 			else
-				il.AddInstruction(il.Jump(ReadILOperand(il, instr, 1)));
+				il.AddInstruction(il.Jump(ReadILOperand(il, instr, 1, registerSize)));
 			return false;
 		case MIPS_LBUX:
 		case MIPS_LBU:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ZeroExtend(4, ReadILOperand(il, instr, 2, 1))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ZeroExtend(4, ReadILOperand(il, instr, 2, registerSize, 1))));
 			break;
 		case MIPS_LB:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, ReadILOperand(il, instr, 2, 1))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, ReadILOperand(il, instr, 2, registerSize, 1))));
 			break;
 		case MIPS_MFHI:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Register(4, REG_HI)));
@@ -415,10 +433,10 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Register(4, REG_LO)));
 			break;
 		case MIPS_MTHI:
-			il.AddInstruction(il.SetRegister(4, REG_HI, ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.SetRegister(4, REG_HI, ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_MTLO:
-			il.AddInstruction(il.SetRegister(4, REG_LO, ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.SetRegister(4, REG_LO, ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_MFC0:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Register(4, REG_COP0)));
@@ -430,27 +448,27 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Register(4, REG_COP2)));
 			break;
 		case MIPS_MTC0:
-			il.AddInstruction(il.SetRegister(4, REG_COP0, ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.SetRegister(4, REG_COP0, ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_MTC1:
-			il.AddInstruction(il.SetRegister(4, op2.reg, ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.SetRegister(4, op2.reg, ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_MTC2:
-			il.AddInstruction(il.SetRegister(4, REG_COP2,  ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.SetRegister(4, REG_COP2,  ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_MOVE:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2)));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2, registerSize)));
 			break;
 		case MIPS_MOVN:
-			il.AddInstruction(il.If(il.CompareNotEqual(4, ReadILOperand(il, instr, 3), il.Const(4, 0)), trueCode, falseCode));
+			il.AddInstruction(il.If(il.CompareNotEqual(4, ReadILOperand(il, instr, 3, registerSize), il.Const(4, 0)), trueCode, falseCode));
 			il.MarkLabel(trueCode);
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2)));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2, registerSize)));
 			il.MarkLabel(falseCode);
 			break;
 		case MIPS_MOVZ:
-			il.AddInstruction(il.If(il.CompareEqual(4, ReadILOperand(il, instr, 3), il.Const(4, 0)), trueCode, falseCode));
+			il.AddInstruction(il.If(il.CompareEqual(4, ReadILOperand(il, instr, 3, registerSize), il.Const(4, 0)), trueCode, falseCode));
 			il.MarkLabel(trueCode);
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2)));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2, registerSize)));
 			il.MarkLabel(falseCode);
 			break;
 		case MIPS_MSUB:
@@ -462,7 +480,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 					il.Or(8, il.ShiftLeft(8, il.Register(4, REG_HI), il.Const(1, 32)), il.ZeroExtend(8, il.Register(4, REG_LO)))));
 			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO,
 					il.Sub(8, il.Register(8, LLIL_TEMP(0)),
-					il.MultDoublePrecSigned(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)))));
+					il.MultDoublePrecSigned(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)))));
 			break;
 		case MIPS_MSUBU:
 			//(HI,LO) = (HI,LO) - (GPR[rs] x GPR[rt])
@@ -473,30 +491,30 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 					il.Or(8, il.ShiftLeft(8, il.Register(4, REG_HI), il.Const(1, 32)), il.ZeroExtend(8, il.Register(4, REG_LO)))));
 			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO,
 					il.Sub(8, il.Register(8, LLIL_TEMP(0)),
-					il.MultDoublePrecUnsigned(8, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)))));
+					il.MultDoublePrecUnsigned(8, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)))));
 			break;
 		case MIPS_MULT:
-			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO, il.MultDoublePrecSigned(8, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2))));
+			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO, il.MultDoublePrecSigned(8, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_MULTU:
-			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO, il.MultDoublePrecUnsigned(8, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2))));
+			il.AddInstruction(il.SetRegisterSplit(4, REG_HI, REG_LO, il.MultDoublePrecUnsigned(8, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_NEG:
 		case MIPS_NEGU:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
-									il.Neg(4, ReadILOperand(il, instr, 2))));
+									il.Neg(4, ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_NOT:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
-									il.Not(4, ReadILOperand(il, instr, 2))));
+									il.Not(4, ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_NOR:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
-									il.Not(4, il.Or(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3)))));
+									il.Not(4, il.Or(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize)))));
 			break;
 		case MIPS_OR:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
-									il.Or(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3))));
+									il.Or(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_ORI:
 			if (op2.reg == REG_ZERO)
@@ -504,17 +522,17 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			else
 				il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 								il.Or(4,
-									ReadILOperand(il, instr, 2),
+									ReadILOperand(il, instr, 2, registerSize),
 									il.Operand(1, il.Const(4, 0x0000ffff & op3.immediate)))));
 			break;
 		case MIPS_RDHWR:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Unimplemented()));
 			break;
 		case MIPS_SW:
-			il.AddInstruction(il.Store(4, GetILOperandMemoryAddress(il, op2, addrSize), ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.Store(4, GetILOperandMemoryAddress(il, op2, addrSize), ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_SD:
-			il.AddInstruction(il.Store(8, GetILOperandMemoryAddress(il, op2, addrSize), ReadILOperand(il, instr, 1)));
+			il.AddInstruction(il.Store(8, GetILOperandMemoryAddress(il, op2, addrSize), ReadILOperand(il, instr, 1, registerSize)));
 			break;
 		case MIPS_SWC1:
 			il.AddInstruction(WriteILOperand(il, instr, 1, addrSize, il.Register(4, REG_COP1)));
@@ -528,12 +546,12 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_SWL:
 			il.AddInstruction(il.Store(2,
 				GetILOperandMemoryAddress(il, op2, addrSize),
-				il.LogicalShiftRight(4, ReadILOperand(il, instr, 1), il.Const(1, 16))));
+				il.LogicalShiftRight(4, ReadILOperand(il, instr, 1, registerSize), il.Const(1, 16))));
 			break;
 		case MIPS_SWR:
 			il.AddInstruction(il.Store(2,
 				il.Sub(4, GetILOperandMemoryAddress(il, op2, addrSize), il.Const(4, 1)),
-				il.And(4, ReadILOperand(il, instr, 1), il.Const(4, 0xffff))));
+				il.And(4, ReadILOperand(il, instr, 1, registerSize), il.Const(4, 0xffff))));
 			break;
 		case MIPS_SYSCALL:
 			il.AddInstruction(il.SystemCall());
@@ -543,7 +561,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg,
 						il.And(4,
 							il.Const(4, (1<<op4.immediate)-1),
-							il.ShiftLeft(4, ReadILOperand(il, instr, 2),
+							il.ShiftLeft(4, ReadILOperand(il, instr, 2, registerSize),
 								il.Const(1, op3.immediate)))));
 			break;
 		case MIPS_INS:
@@ -551,10 +569,10 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 						il.Or(4,
 							il.And(4,
 								il.Const(4, ((1<<op4.immediate)-1)<<op3.immediate),
-								ReadILOperand(il, instr, 1)),
+								ReadILOperand(il, instr, 1, registerSize)),
 							il.And(4,
 								il.Const(4, (1<<op4.immediate)-1),
-								ReadILOperand(il, instr, 2)))));
+								ReadILOperand(il, instr, 2, registerSize)))));
 			break;
 		case MIPS_LUI:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.Const(4, op2.immediate << 16)));
@@ -563,69 +581,72 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_LW:
 		case MIPS_LWX:
 		case MIPS_LL: // TODO: Atomic access primitives
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2)));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, ReadILOperand(il, instr, 2, registerSize)));
+			break;
+		case MIPS_LD:
+			il.AddInstruction(SetRegisterOrNop(il, 8, op1.reg, ReadILOperand(il, instr, 2, registerSize)));
 			break;
 		case MIPS_SRA:
 		case MIPS_SRAV:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ArithShiftRight(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ArithShiftRight(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_SLT:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.BoolToInt(4,
-				il.CompareSignedLessThan(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3)))));
+				il.CompareSignedLessThan(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize)))));
 			break;
 		case MIPS_SLTI:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.BoolToInt(4,
-				il.CompareSignedLessThan(4, ReadILOperand(il, instr, 2), il.Const(4, op3.immediate)))));
+				il.CompareSignedLessThan(4, ReadILOperand(il, instr, 2, registerSize), il.Const(4, op3.immediate)))));
 			break;
 		case MIPS_SLTIU:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.BoolToInt(4,
-				il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 2), il.Const(4, op3.immediate)))));
+				il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 2, registerSize), il.Const(4, op3.immediate)))));
 			break;
 		case MIPS_SLTU:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.BoolToInt(4,
-				il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3)))));
+				il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize)))));
 			break;
 		case MIPS_SLL:
 		case MIPS_SLLV:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ShiftLeft(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ShiftLeft(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_SB:
-			il.AddInstruction(il.Store(1, GetILOperandMemoryAddress(il, op2, addrSize), il.LowPart(1, ReadILOperand(il, instr, 1))));
+			il.AddInstruction(il.Store(1, GetILOperandMemoryAddress(il, op2, addrSize), il.LowPart(1, ReadILOperand(il, instr, 1, registerSize))));
 			break;
 		case MIPS_TRAP:
 			il.AddInstruction(il.Trap(0));
 			break;
 		case MIPS_TEQI:
 		case MIPS_TEQ:
-			ConditionExecute(il, il.CompareEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareEqual(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_TNE:
 		case MIPS_TNEI:
-			ConditionExecute(il, il.CompareNotEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareNotEqual(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_TGE:
 		case MIPS_TGEI:
-			ConditionExecute(il, il.CompareSignedGreaterEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareSignedGreaterEqual(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_TGEIU:
 		case MIPS_TGEU:
-			ConditionExecute(il, il.CompareUnsignedGreaterEqual(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareUnsignedGreaterEqual(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_TLT:
 		case MIPS_TLTI:
-			ConditionExecute(il, il.CompareSignedLessThan(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareSignedLessThan(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_TLTIU:
 		case MIPS_TLTU:
-			ConditionExecute(il, il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)),il.Trap(0));
+			ConditionExecute(il, il.CompareUnsignedLessThan(4, ReadILOperand(il, instr, 1, registerSize), ReadILOperand(il, instr, 2, registerSize)),il.Trap(0));
 			break;
 		case MIPS_LH:
 		case MIPS_LHX:
 		case MIPS_LHI:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, ReadILOperand(il, instr, 2, 2))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, ReadILOperand(il, instr, 2, registerSize, 2))));
 			break;
 		case MIPS_LHU:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ZeroExtend(4, ReadILOperand(il, instr, 2, 2))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.ZeroExtend(4, ReadILOperand(il, instr, 2, registerSize, 2))));
 			break;
 		case MIPS_LWL:
 		case MIPS_LWR:
@@ -640,23 +661,23 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(il.Unimplemented());
 			break;
 		case MIPS_SC:
-			il.AddInstruction(il.UnimplementedMemoryRef(4, ReadILOperand(il, instr, 2)));
+			il.AddInstruction(il.UnimplementedMemoryRef(4, ReadILOperand(il, instr, 2, registerSize)));
 			break;
 		case MIPS_SDBBP:
 			il.AddInstruction(il.Unimplemented());
 			break;
 		case MIPS_SEB:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, il.LowPart(1, ReadILOperand(il, instr, 2)))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, il.LowPart(1, ReadILOperand(il, instr, 2, registerSize)))));
 			break;
 		case MIPS_SEH:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, il.LowPart(2, ReadILOperand(il, instr, 2)))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.SignExtend(4, il.LowPart(2, ReadILOperand(il, instr, 2, registerSize)))));
 			break;
 		case MIPS_SH:
-			il.AddInstruction(il.Store(2, GetILOperandMemoryAddress(il, op2, addrSize), il.LowPart(2, ReadILOperand(il, instr, 1))));
+			il.AddInstruction(il.Store(2, GetILOperandMemoryAddress(il, op2, addrSize), il.LowPart(2, ReadILOperand(il, instr, 1, registerSize))));
 			break;
 		case MIPS_SRL:
 		case MIPS_SRLV:
-			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.LogicalShiftRight(4, ReadILOperand(il, instr, 2), ReadILOperand(il, instr, 3))));
+			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.LogicalShiftRight(4, ReadILOperand(il, instr, 2, registerSize), ReadILOperand(il, instr, 3, registerSize))));
 			break;
 		case MIPS_SSNOP:
 		case MIPS_NOP:
@@ -708,11 +729,11 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 				il.FloatSqrt(8, il.RegisterSplit(4, op2.reg | 1, op2.reg & (~1)))));
 			break;
 		case MIPS_CVT_S_W:
-			il.AddInstruction(il.SetRegister(4, op1.reg, il.IntToFloat(4, ReadILOperand(il, instr, 2))));
+			il.AddInstruction(il.SetRegister(4, op1.reg, il.IntToFloat(4, ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_CVT_D_W:
 			il.AddInstruction(il.SetRegisterSplit(4, op1.reg | 1, op1.reg & (~1),
-				il.IntToFloat(8, ReadILOperand(il, instr, 2))));
+				il.IntToFloat(8, ReadILOperand(il, instr, 2, registerSize))));
 			break;
 		case MIPS_CVT_W_S:
 			il.AddInstruction(SetRegisterOrNop(il, 4, op1.reg, il.FloatToInt(4, il.Register(4, op2.reg))));
@@ -834,10 +855,6 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			}
 			break;
 		case MIPS_ADDR:
-		case MIPS_DADD:
-		case MIPS_DADDI:
-		case MIPS_DADDIU:
-		case MIPS_DADDU:
 		case MIPS_DSLL32:
 		case MIPS_DSLL:
 		case MIPS_DSLLV:
@@ -850,7 +867,6 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		case MIPS_DSUB:
 		case MIPS_DSUBU:
 		case MIPS_ERET:
-		case MIPS_LD:
 		case MIPS_LDL:
 		case MIPS_LDR:
 		case MIPS_LDXC1:

--- a/il.h
+++ b/il.h
@@ -10,4 +10,4 @@ bool GetLowLevelILForInstruction(
 		mips::Instruction& instr,
 		size_t addrSize);
 
-BinaryNinja::ExprId GetConditionForInstruction(BinaryNinja::LowLevelILFunction& il, mips::Instruction& instr);
+BinaryNinja::ExprId GetConditionForInstruction(BinaryNinja::LowLevelILFunction& il, mips::Instruction& instr, size_t registerSize);

--- a/mips/mips.c
+++ b/mips/mips.c
@@ -1387,14 +1387,14 @@ uint32_t mips_decompose_instruction(
 		case MIPS_BLTZALL:
 		case MIPS_BLTZL:
 		case MIPS_BEQZ:
-			INS_2(REG, ins.i.rs, LABEL, (4 + ins.i.immediate<<2) & registerMask)
+			INS_2(REG, ins.i.rs, LABEL, (4 + address + (ins.i.immediate<<2)) & registerMask)
 			break;
 		case MIPS_BGTZ:
 		case MIPS_BGTZL:
 		case MIPS_BLEZ:
 		case MIPS_BLEZL:
 		case MIPS_BLTZ:
-			INS_2(REG, ins.i.rs, LABEL, (4 + address + (ins.i.immediate<<2) & registerMask))
+			INS_2(REG, ins.i.rs, LABEL, (4 + address + (ins.i.immediate<<2)) & registerMask)
 			if (ins.i.rt != 0)
 				return 1;
 			break;
@@ -1732,7 +1732,7 @@ uint32_t mips_decompose_instruction(
 		case MIPS_BEQL:
 		case MIPS_BNE:
 		case MIPS_BNEL:
-			INS_3(REG, ins.i.rs, REG, ins.i.rt, LABEL, (4 + address + (ins.i.immediate<<2) & registerMask))
+			INS_3(REG, ins.i.rs, REG, ins.i.rt, LABEL, (4 + address + (ins.i.immediate<<2)) & registerMask)
 			break;
 		case MIPS_ROTR:
 			INS_3(REG, ins.r.rd, REG, ins.r.rt, IMM, ins.r.sa)

--- a/mips/mips.h
+++ b/mips/mips.h
@@ -463,10 +463,14 @@ namespace mips
 		REG_A1,
 		REG_A2,
 		REG_A3,
-		REG_T0,      // Temporaries
+		REG_T0,      // Temporaries, or extra arguments if N64
+		REG_A4 = REG_T0,
 		REG_T1,
+		REG_A5 = REG_T1,
 		REG_T2,
+		REG_A6 = REG_T2,
 		REG_T3,
+		REG_A7 = REG_T3,
 		REG_T4,
 		REG_T5,
 		REG_T6,
@@ -601,6 +605,7 @@ namespace mips
 		MIPS_3,
 		MIPS_4,
 		MIPS_32,
+		MIPS_64,
 		MIPS_VERSION_END
 	};
 
@@ -715,7 +720,7 @@ namespace mips
 	struct InstructionOperand {
 		uint32_t operandClass;
 		uint32_t reg;
-		uint32_t immediate;
+		uint64_t immediate;
 	};
 
 #ifndef __cplusplus


### PR DESCRIPTION
Starting to add disassembly/lifting for MIPS64. A lot doesn't work at the moment, but a surprising amount does. Currently only big endian, but just because I don't have a little endian MIPS64 binary to test with right now.

The biggest problem I see right now is that there is no `EM_MIPS64` (ELF machine type code) - it reuses `EM_MIPS`. Binja seems to default to the most recently registered architecture that works, so it arbitrarily chooses MIPS64 for _all_ MIPS ELFs now. You can force it in the load options, but you also have to change the platform from `mips64` to `linux-mips32` or whatever. Any better ideas for fixing that?

Decent test binaries for this stuff: https://busybox.net/downloads/binaries/1.21.1/