### PR TITLE
Fix cmake to properly link binaryninjacore on msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ if((NOT BN_API_PATH) AND (NOT BN_INTERNAL_BUILD))
 		message(FATAL_ERROR "Provide path to Binary Ninja API source in BN_API_PATH")
 	endif()
 endif()
+
+if((NOT BN_INSTALL_DIR) AND (NOT BN_INTERNAL_BUILD) AND WIN32)
+	set(BN_INSTALL_DIR $ENV{BN_INSTALL_DIR})
+	if(NOT BN_INSTALL_DIR)
+		message(FATAL_ERROR "Provide path to Binary Ninja installation in BN_INSTALL_DIR")
+	endif()
+endif()
+
 if(NOT BN_INTERNAL_BUILD)
 	add_subdirectory(${BN_API_PATH} ${PROJECT_BINARY_DIR}/api)
 endif()
@@ -28,7 +36,13 @@ target_include_directories(arch_mips
 	PRIVATE ${PROJECT_SOURCE_DIR}
 	PRIVATE ${PROJECT_SOURCE_DIR}/mips)
 
-target_link_libraries(arch_mips binaryninjaapi)
+if(WIN32)
+	target_link_directories(arch_mips
+		PRIVATE ${BN_INSTALL_DIR})
+	target_link_libraries(arch_mips binaryninjaapi binaryninjacore)
+else()
+	target_link_libraries(arch_mips binaryninjaapi)
+endif()
 
 set_target_properties(arch_mips PROPERTIES
     CXX_STANDARD 17


### PR DESCRIPTION
Some major caveats here:
- I don't know CMake
- I have not tested this on not-windows

It's entirely possive Ive screwed something up here, but on Windows if
you want to dynamically link binaryninjacore.dll, at compile time you'll
need to link the respective static import lib, binaryninjacore.lib. As
far as I can tell, no architecture does this.

If this patch is correct, it should also be applied to arch-arm64 and
probably others.