### PR TITLE
lift wsbh

### DIFF
--- a/arch_mips.cpp
+++ b/arch_mips.cpp
@@ -772,6 +772,46 @@ public:
 		return true;
 	}
 
+	virtual string GetIntrinsicName(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+			case MIPS_INTRIN_WSBH:
+				return "__wsbh";
+			default:
+				return "";
+		}
+	}
+
+	virtual vector<uint32_t> GetAllIntrinsics() override
+	{
+		return vector<uint32_t>{
+			MIPS_INTRIN_WSBH,
+		};
+	}
+
+	virtual vector<NameAndType> GetIntrinsicInputs(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+			case MIPS_INTRIN_WSBH:
+				return {NameAndType(Type::IntegerType(4, false))};
+			default:
+				return vector<NameAndType>();
+		}
+	}
+
+	virtual vector<Confidence<Ref<Type>>> GetIntrinsicOutputs(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+			case MIPS_INTRIN_WSBH:
+				return {Type::IntegerType(4, false)};
+			default:
+				return vector<Confidence<Ref<Type>>>();
+		}
+	}
+
 	virtual bool IsNeverBranchPatchAvailable(const uint8_t* data, uint64_t addr, size_t len) override
 	{
 		Instruction instr;

--- a/il.cpp
+++ b/il.cpp
@@ -708,7 +708,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 			il.AddInstruction(il.Nop());
 			break;
 		case MIPS_WSBH:
-			il.AddInstruction(il.Unimplemented());
+			il.AddInstruction(il.Intrinsic({RegisterOrFlag::Register(op1.reg)}, MIPS_INTRIN_WSBH, {ReadILOperand(il, instr, 2, registerSize)}));
 			break;
 		case MIPS_BGEZALL:
 		case MIPS_BLTZALL:

--- a/il.h
+++ b/il.h
@@ -1,7 +1,14 @@
 #pragma once
 
 #include "binaryninjaapi.h"
+#include "lowlevelilinstruction.h"
 #include "mips.h"
+
+enum MipsIntrinsic : uint32_t
+{
+		MIPS_INTRIN_WSBH,
+		MIPS_INTRIN_INVALID=0xFFFFFFFF,
+};
 
 bool GetLowLevelILForInstruction(
 		BinaryNinja::Architecture* arch,


### PR DESCRIPTION
wsbh is "word swap bytes within halfword". Similar to arm64, this is just lifted as an intrinsic as opposed to lifting manually. This is done under the assumption that this data will not be useful to recover dataflow. Should this turn out to not be the case, we can always decompose and lift to match the underlying semantics.