### PR TITLE
properly handle delay slot rewriting with call targets

### DIFF
--- a/arch_mips.cpp
+++ b/arch_mips.cpp
@@ -542,7 +542,7 @@ public:
 					// to be correct in the general case. also, it uses LLIL_TEMP(1) for the simple reason
 					// that the mips lifter only uses LLIL_TEMP(0) at the moment.
 					LowLevelILInstruction lifted = il.GetInstruction(instrIdx);
-					if ((lifted.operation == LLIL_IF) && (lifted.address == addr))
+					if ((lifted.operation == LLIL_IF || lifted.operation == LLIL_CALL) && (lifted.address == addr))
 					{
 						bool replace = false;
 


### PR DESCRIPTION
mips can sometime have code like this:

```
li      $at, 0x665f4
jalr    $at  {__copy_user}
addu    $at, $a1, $a2  {__copy_user}
```

Currently, this gets rewritten into `call($a1 + $a2)`. This patch re-uses the existing nop rewriting and just ops LLIL_CALLs into them.