### PR TITLE
added setting to allow disabling generation of pseudo-ops

### DIFF
--- a/mips/mips.c
+++ b/mips/mips.c
@@ -1888,7 +1888,8 @@ uint32_t mips_decompose(
 		Instruction* restrict instruction,
 		uint32_t version,
 		uint64_t address,
-		uint32_t endianBig)
+		uint32_t endianBig,
+		uint32_t enablePseudoOps)
 {
 	combined ins;
 	if (instructionValue == NULL)
@@ -1904,7 +1905,7 @@ uint32_t mips_decompose(
 		return result;
 	instruction->size = 4;
 	//look for peudoinstructions by disassembling the next instruction too
-	if (size >= 8)
+	if (enablePseudoOps != 0 && size >= 8)
 	{
 		if (endianBig == 1)
 			ins.value = bswap32(instructionValue[1]);

--- a/mips/mips.h
+++ b/mips/mips.h
@@ -754,7 +754,8 @@ namespace mips
 				Instruction* restrict instruction,
 				MipsVersion version,
 				uint64_t address,
-				uint32_t bigEndian);
+				uint32_t bigEndian,
+				uint32_t enablePseudoOps);
 
 		//Get a text representation of the decomposed instruction
 		//into outBuffer

--- a/mips/test.c
+++ b/mips/test.c
@@ -17,7 +17,7 @@ int disassemble(uint32_t insword, uint64_t address, enum MipsVersion version, ch
 	uint32_t bigendian = 0;
 
 	memset(&instr, 0, sizeof(instr));
-	rc = mips_decompose(&insword, 4, &instr, version, address, bigendian);
+	rc = mips_decompose(&insword, 4, &instr, version, address, bigendian, 1);
 	if(rc) {
 		printf("ERROR: mips_decompose() returned %d\n", rc);
 		return rc;


### PR DESCRIPTION
Does anyone have an issue with this change, which adds a Setting to the mips arch plugin to disable it from emitting pseudo-ops?